### PR TITLE
Feature: Resolution Modules

### DIFF
--- a/IntuitionisticTheoremProver.cabal
+++ b/IntuitionisticTheoremProver.cabal
@@ -31,13 +31,13 @@ library
       Prover
       Formula
       Utilities
+      Hypersequent
+      Sequent
   other-modules:
       Paths_IntuitionisticTheoremProver
       Canonicalizer
-      Hypersequent
       IntuitionisticTranslator
       Model
-      Sequent
   hs-source-dirs:
       src
   build-depends: base >=4.7 && <5, containers, hspec >= 2.7.4, parallel

--- a/src/Formula.hs
+++ b/src/Formula.hs
@@ -11,6 +11,7 @@ module Formula
     , disjunctionP
     , conjunctionP
     , negationP
+    , negationOfP
     , possibilityP
     , necessityP
     , joinStrings
@@ -404,6 +405,11 @@ conjunctionP _ = False
 negationP :: Formula -> Bool
 negationP (Not _) = True
 negationP _ = False
+
+negationOfP :: Formula -> Formula -> Bool
+negationOfP (Not negatum) formula = negatum == formula
+negationOfP formula (Not negatum) = negatum == formula
+negationOfP _ _ = False
 
 doubleNegationP :: Formula -> Bool
 doubleNegationP (Not (Not _)) = True

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,5 +1,7 @@
 import Test.Hspec
 import Formula
+import Sequent
+import Hypersequent
 import Prover
 import Utilities
 
@@ -14,6 +16,7 @@ main :: IO()
 main = hspec $ do
    describe "Cartesian Product Tests" spec_cartesianProduct
    describe "Prove Tests" spec_prove
+   describe "Resolution Module: Positive Reflexivity" spec_positiveReflexivityResolutionModule
 
 spec_cartesianProduct :: Spec
 spec_cartesianProduct = do
@@ -31,6 +34,18 @@ spec_cartesianProduct = do
 
   it (show [[1,0]] ++ " should be " ++ show [[1], [0]]) $
     cartesianProduct [[1,0]] `shouldBe` [[1], [0]]
+
+spec_positiveReflexivityResolutionModule :: Spec
+spec_positiveReflexivityResolutionModule = do
+  it (show (World (Sequent [] [Not p , Possibly p, q, Necessarily q]) []) ++ " should be True") $
+     moduleMatches PositiveReflexivity (World (Sequent [] [Not p , Possibly p, q, Necessarily q]) []) `shouldBe` True
+
+  it (show (World (Sequent [] [Not p , Possibly p, q, Necessarily q]) []) ++ " should be " ++ show (Node (World (Sequent [] [Not p , Possibly p, q, Necessarily q]) [])
+                                                                                                    [Node (World (Sequent [p] [p, Possibly p, q, Necessarily q]) [])
+                                                                                                     [Closed]])) $
+     applyModule PositiveReflexivity (World (Sequent [] [Not p , Possibly p, q, Necessarily q]) []) `shouldBe` Node (World (Sequent [] [Not p , Possibly p, q, Necessarily q]) [])
+                                                                                                    [Node (World (Sequent [p] [p, Possibly p, q, Necessarily q]) [])
+                                                                                                     [Closed]]
 
 spec_prove :: Spec
 spec_prove = do
@@ -70,9 +85,9 @@ spec_prove = do
   it (show (Implies p p) ++ " should be Proved") $
      prove (Implies p p) `shouldBe` Proved
 
---  it (show (Implies (And [p, Implies p q,Implies q (AtomicFormula "r")]) (AtomicFormula "r")) ++ " should be Proved") $
---     prove (Implies (And [p, Implies p q,Implies q (AtomicFormula "r")]) (AtomicFormula "r")) `shouldBe` Proved
---
+  it (show (Implies (And [p, Implies p q,Implies q (AtomicFormula "r")]) (AtomicFormula "r")) ++ " should be Proved") $
+     prove (Implies (And [p, Implies p q,Implies q (AtomicFormula "r")]) (AtomicFormula "r")) `shouldBe` Proved
+
 --  it (show (Equivalent (Equivalent p q)(Equivalent q p)) ++ " should be Proved") $
 --     prove (Equivalent (Equivalent p q)(Equivalent q p)) `shouldBe` Proved
 


### PR DESCRIPTION
A Resolution Module captures a pattern that is often seen when proving
things to prevent the prover from going down rabbit holes. For
example, we often saw the pattern G => (Necessarily p), (Possibly (Not
p)), S but because of formulas that were around that one, the prover
would not prune branches quickly enough to close the tree. The
addition of resolution modules allows the prover to look for specific
patterns and trim a proof tree based on them.

A resolution module has two parts that need to be specified:

   1.  The pattern that it is going to look for -- this is at the
   level of a sequent
   2.  The rules that it is going to apply to the hypersequent that
   it applies to to turn it into a closed branch.